### PR TITLE
changes to wysiwyg tinymce helper

### DIFF
--- a/views/helpers/tinymce.php
+++ b/views/helpers/tinymce.php
@@ -97,7 +97,7 @@ class TinymceHelper extends AppHelper {
 		$selector = "data[{$this->__modelFieldPair['model']}][{$this->__modelFieldPair['field']}]";
 
 		if (isset($options['class'])) {
-			$options['class'] .= $selector;
+			$options['class'] .= ' ' . $selector;
 		} else {
 			$options['class'] = $selector;
 		}
@@ -114,12 +114,12 @@ class TinymceHelper extends AppHelper {
  * @return string An HTML textarea element with TinyMCE
  */
 	function textarea($field, $options = array(), $tinyoptions = array()) {
-		$options['type'] = 'textareas';
+		$options['type'] = 'textarea';
 		$this->__field($field);
 		$selector = "data[{$this->__modelFieldPair['model']}][{$this->__modelFieldPair['field']}]";
 
 		if (isset($options['class'])) {
-			$options['class'] .= $selector;
+			$options['class'] .= ' ' . $selector;
 		} else {
 			$options['class'] = $selector;
 		}


### PR DESCRIPTION
Adjusted class value with a space when adding the model name (selector)  when there is already a class defined in the options.  Additionally, on the textarea function  changed  type from textareas to textarea.  
