### PR TITLE
Update WysiwygHelper.php

### DIFF
--- a/View/Helper/WysiwygHelper.php
+++ b/View/Helper/WysiwygHelper.php
@@ -99,7 +99,7 @@ class WysiwygHelper extends WysiwygAppHelper {
  * @return string
  * @author Jose Diaz-Gonzalez
  */
-	public function input($field, $options = array(), $editorOptions = array()) {
+	public function input($field = null, $options = array(), $editorOptions = array()) {
 		$editorHelper = $this->helper;
 		$editorOptions = Set::merge($this->_editorDefaults, $editorOptions);
 
@@ -115,7 +115,7 @@ class WysiwygHelper extends WysiwygAppHelper {
  * @return string
  * @author Jose Diaz-Gonzalez
  */
-	public function textarea($field, $options = array(), $editorOptions = array()) {
+	public function textarea($field = null, $options = array(), $editorOptions = array()) {
 		$editorHelper = $this->helper;
 		$editorOptions = Set::merge($this->_editorDefaults, $editorOptions);
 


### PR DESCRIPTION
Hi, I'm getting 2 errors in CakePHP 2.3.

Strict (2048): Declaration of WysiwygHelper::input() should be compatible with WysiwygAppHelper::input($fieldName = NULL, $options = Array, $helperOptions = Array) [APP\Plugin\Wysiwyg\View\Helper\WysiwygHelper.php, line 15]

Strict (2048): Declaration of WysiwygHelper::textarea() should be compatible with WysiwygAppHelper::textarea($fieldName = NULL, $options = Array, $helperOptions = Array) [APP\Plugin\Wysiwyg\View\Helper\WysiwygHelper.php, line 15]
