### PR TITLE
Add option to set which block scripts will be added to.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -125,6 +125,7 @@ The following are special settings that are used internally by the `Wysiwyg` plu
 - `_cssText`: A text string containing relevant css
 - `_editor`: The editor class. Used only when you specify the `Wysiwyg.Wysiwyg` helper
 - `_scripts`: An array of scripts to buffer
+- `_scriptBlock`: Override which block the scripts will be added to
 
 These will be ignored when passing settings onto the wysiwyg javascript you are configuring.
 

--- a/View/Helper/WysiwygAppHelper.php
+++ b/View/Helper/WysiwygAppHelper.php
@@ -119,9 +119,15 @@ class WysiwygAppHelper extends AppHelper {
 			$this->_View->append('css', $out);
 		}
 
+        if (!empty($options['_scriptBlock'])) {
+            $scriptOpts = array('block' => $options['_scriptBlock']);
+        } else {
+            $scriptOpts = false;
+        }
+
 		if (!empty($options['_scripts'])) {
 			foreach ((array)$options['_scripts'] as $script) {
-				$this->Html->script($script, false);
+				$this->Html->script($script, $scriptOpts);
 			}
 		}
 	}
@@ -138,6 +144,7 @@ class WysiwygAppHelper extends AppHelper {
 			'_css' => true,
 			'_cssText' => true,
 			'_scripts' => true,
+			'_scriptBlock' => false,
 			'_editor' => true,
 		);
 


### PR DESCRIPTION
This addresses issues brought up in #15 by adding an option to define a block for the scripts to be added to.

Example:

``` php
echo $this->Wysiwyg->input('left_field', array('class' => 'supergeil'), array('_scriptBlock' => 'scriptBottom');
```
