### PR TITLE
Allow inline false

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -131,6 +131,7 @@ The following are special settings that are used internally by the `Wysiwyg` plu
 - `_editor`: The editor class. Used only when you specify the `Wysiwyg.Wysiwyg` helper
 - `_scripts`: An array of scripts to buffer
 - `_scriptBlock`: Override which block the scripts will be added to
+- `_inline`: Prints js in script block insted of next to input. Default: true
 
 These will be ignored when passing settings onto the wysiwyg javascript you are configuring.
 

--- a/View/Helper/CkHelper.php
+++ b/View/Helper/CkHelper.php
@@ -56,7 +56,7 @@ class CkHelper extends WysiwygAppHelper {
 			return '';
 		}
 
-		return $this->Html->scriptBlock($script, array('safe' => false));
+		return $this->Html->scriptBlock($script, array('safe' => false, 'inline' => $options['_inline']));
 	}
 
 }

--- a/View/Helper/CkHelper.php
+++ b/View/Helper/CkHelper.php
@@ -44,7 +44,7 @@ class CkHelper extends WysiwygAppHelper {
 			'_scripts' => array(
 				'core' => 'ck/ckeditor.js',
 			),
-            '_inline' => true,
+			'_inline' => true,
 		), $options);
 
 		$this->_initialize($options);

--- a/View/Helper/CkHelper.php
+++ b/View/Helper/CkHelper.php
@@ -44,6 +44,7 @@ class CkHelper extends WysiwygAppHelper {
 			'_scripts' => array(
 				'core' => 'ck/ckeditor.js',
 			),
+            '_inline' => true,
 		), $options);
 
 		$this->_initialize($options);

--- a/View/Helper/JwysiwygHelper.php
+++ b/View/Helper/JwysiwygHelper.php
@@ -49,7 +49,7 @@ class JwysiwygHelper extends WysiwygAppHelper {
 				'core' => '/js/jwysiwyg/jquery.wysiwyg.css',
 			),
 			'initialContent' => '',
-            '_inline' => true,
+			'_inline' => true,
 		), $options);
 
 		$this->_initialize($options);

--- a/View/Helper/JwysiwygHelper.php
+++ b/View/Helper/JwysiwygHelper.php
@@ -49,6 +49,7 @@ class JwysiwygHelper extends WysiwygAppHelper {
 				'core' => '/js/jwysiwyg/jquery.wysiwyg.css',
 			),
 			'initialContent' => '',
+            '_inline' => true,
 		), $options);
 
 		$this->_initialize($options);

--- a/View/Helper/JwysiwygHelper.php
+++ b/View/Helper/JwysiwygHelper.php
@@ -61,7 +61,7 @@ class JwysiwygHelper extends WysiwygAppHelper {
 			return '';
 		}
 
-		return $this->Html->scriptBlock($script, array('safe' => false));
+		return $this->Html->scriptBlock($script, array('safe' => false, 'inline' => $options['_inline']));
 	}
 
 }

--- a/View/Helper/MarkitupHelper.php
+++ b/View/Helper/MarkitupHelper.php
@@ -65,7 +65,7 @@ class MarkitupHelper extends WysiwygAppHelper {
 			return '';
 		}
 
-		return $this->Html->scriptBlock($script, array('safe' => false));
+		return $this->Html->scriptBlock($script, array('safe' => false, 'inline' => $options['_inline']));
 	}
 
 }

--- a/View/Helper/MarkitupHelper.php
+++ b/View/Helper/MarkitupHelper.php
@@ -49,7 +49,7 @@ class MarkitupHelper extends WysiwygAppHelper {
 				'set' => '/js/markitup/sets/default/style.css',
 				'skin' => '/js/markitup/skins/markitup/style.css'
 			),
-            '_inline' => true,
+			'_inline' => true,
 		), $options);
 
 		$this->_initialize($options);

--- a/View/Helper/MarkitupHelper.php
+++ b/View/Helper/MarkitupHelper.php
@@ -49,6 +49,7 @@ class MarkitupHelper extends WysiwygAppHelper {
 				'set' => '/js/markitup/sets/default/style.css',
 				'skin' => '/js/markitup/skins/markitup/style.css'
 			),
+            '_inline' => true,
 		), $options);
 
 		$this->_initialize($options);

--- a/View/Helper/NiceditHelper.php
+++ b/View/Helper/NiceditHelper.php
@@ -70,7 +70,7 @@ CSS;
 			return '';
 		}
 
-		return $this->Html->scriptBlock($script, array('safe' => false));
+		return $this->Html->scriptBlock($script, array('safe' => false, 'inline' => $options['_inline']));
 	}
 
 }

--- a/View/Helper/NiceditHelper.php
+++ b/View/Helper/NiceditHelper.php
@@ -56,7 +56,7 @@ CSS;
 			),
 			'_cssText' => $cssText,
 			'iconsPath' => '/js/nicedit/nicEditorIcons.gif',
-            '_inline' => true,
+			'_inline' => true,
 		), $options);
 
 		$options['iconsPath'] = $this->url($options['iconsPath']);

--- a/View/Helper/NiceditHelper.php
+++ b/View/Helper/NiceditHelper.php
@@ -55,7 +55,8 @@ CSS;
 				'core' => 'nicedit/nicEdit.js',
 			),
 			'_cssText' => $cssText,
-			'iconsPath' => '/js/nicedit/nicEditorIcons.gif'
+			'iconsPath' => '/js/nicedit/nicEditorIcons.gif',
+            '_inline' => true,
 		), $options);
 
 		$options['iconsPath'] = $this->url($options['iconsPath']);

--- a/View/Helper/TinymceHelper.php
+++ b/View/Helper/TinymceHelper.php
@@ -45,7 +45,7 @@ class TinymceHelper extends WysiwygAppHelper {
 			'_scripts' => array(
 				'core' => 'tinymce/tinymce.min.js',
 			),
-            '_inline' => true,
+			'_inline' => true,
 		), $options);
 
 		$this->_initialize($options);

--- a/View/Helper/TinymceHelper.php
+++ b/View/Helper/TinymceHelper.php
@@ -45,6 +45,7 @@ class TinymceHelper extends WysiwygAppHelper {
 			'_scripts' => array(
 				'core' => 'tinymce/tinymce.min.js',
 			),
+            '_inline' => true,
 		), $options);
 
 		$this->_initialize($options);

--- a/View/Helper/TinymceHelper.php
+++ b/View/Helper/TinymceHelper.php
@@ -57,7 +57,7 @@ class TinymceHelper extends WysiwygAppHelper {
 			return '';
 		}
 
-		return $this->Html->scriptBlock($script, array('safe' => false));
+		return $this->Html->scriptBlock($script, array('safe' => false, 'inline' => $options['_inline']));
 	}
 
 }

--- a/View/Helper/WysiwygAppHelper.php
+++ b/View/Helper/WysiwygAppHelper.php
@@ -146,7 +146,7 @@ class WysiwygAppHelper extends AppHelper {
 			'_scripts' => true,
 			'_scriptBlock' => false,
 			'_editor' => true,
-            '_inline' => false,
+            '_inline' => true,
 		);
 
 		return json_encode(array_diff_key(array_merge(

--- a/View/Helper/WysiwygAppHelper.php
+++ b/View/Helper/WysiwygAppHelper.php
@@ -146,7 +146,7 @@ class WysiwygAppHelper extends AppHelper {
 			'_scripts' => true,
 			'_scriptBlock' => false,
 			'_editor' => true,
-            '_inline' => true,
+			'_inline' => true,
 		);
 
 		return json_encode(array_diff_key(array_merge(

--- a/View/Helper/WysiwygAppHelper.php
+++ b/View/Helper/WysiwygAppHelper.php
@@ -146,6 +146,7 @@ class WysiwygAppHelper extends AppHelper {
 			'_scripts' => true,
 			'_scriptBlock' => false,
 			'_editor' => true,
+            '_inline' => false,
 		);
 
 		return json_encode(array_diff_key(array_merge(


### PR DESCRIPTION
In my daily work i use to move js to the end of layouts. Before this edit every editor would throw an error for not found libraries (like jQuery). Now you can pass `_inline` => false and your script will be appended at the script block insted of next to input.
